### PR TITLE
fix unity 2018.3 bug

### DIFF
--- a/Assets/BookUI/PageSelector.cs
+++ b/Assets/BookUI/PageSelector.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine.EventSystems;
+﻿using System.Collections;
+using UnityEngine.EventSystems;
 
 namespace UnityEngine.UI.Extensions
 {
@@ -7,16 +8,24 @@ namespace UnityEngine.UI.Extensions
     {
         void Start()
         {
+            StartCoroutine(InitPages());
+        }
+
+        private IEnumerator InitPages()
+        {
+            yield return new WaitForEndOfFrame();
             var book = GetComponent<BookUI>();
             foreach (var target in GetComponentsInChildren<Selectable>())
             {
                 var matrix = book.transform.localToWorldMatrix.inverse * target.transform.localToWorldMatrix;
+
                 float x = matrix.m03 / book.Resolution.x;
 
                 var trigger = target.gameObject.AddComponent<EventTrigger>();
                 EventTrigger.Entry entry = new EventTrigger.Entry();
                 entry.eventID = EventTriggerType.Select;
                 entry.callback.AddListener((eventData) => { book.CurrentPage = Mathf.FloorToInt(x + 0.5f); });
+                trigger.triggers.Clear();
                 trigger.triggers.Add(entry);
             }
         }


### PR DESCRIPTION
I tried to use it in 2018.3 ,but I find it doesn't work, mainly because the time calculate the horizontal layout is delayed, so I just delay the calculate page time too